### PR TITLE
Relax keychain access level

### DIFF
--- a/PIALibrary/Sources/Util/Keychain.swift
+++ b/PIALibrary/Sources/Util/Keychain.swift
@@ -66,6 +66,7 @@ public class Keychain {
         setScope(query: &query)
         query[kSecClass as String] = kSecClassGenericPassword
         query[kSecAttrAccount as String] = username
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
         query[kSecValueData as String] = password.data(using: .utf8)
     
         let status = SecItemAdd(query as CFDictionary, nil)
@@ -91,6 +92,7 @@ public class Keychain {
         setScope(query: &query)
         query[kSecClass as String] = kSecClassGenericPassword
         query[kSecAttrAccount as String] = username
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         query[kSecReturnData as String] = true
         


### PR DESCRIPTION
Credentials may be unavailable while device is locked. Given that the VPN gets its credentials from the keychain, it may not be able to start in the background due to a restrictive keychain access level.

Raise to `AfterFirstUnlock`.