### PR TITLE
Update API to PIATunnel 1.1.3

### DIFF
--- a/PIALibrary.podspec
+++ b/PIALibrary.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
         p.frameworks            = "NetworkExtension"
         p.pod_target_xcconfig   = { "APPLICATION_EXTENSION_API_ONLY" => "YES" }
 
-        p.dependency "PIATunnel", "~> 1.1.2"
+        p.dependency "PIATunnel", "~> 1.1.3"
         p.dependency "PIALibrary/Library"
     end
 

--- a/PIALibrary/Sources/Core/Persistence/PlainStore.swift
+++ b/PIALibrary/Sources/Core/Persistence/PlainStore.swift
@@ -23,8 +23,6 @@ protocol PlainStore: class {
     var cachedServers: [Server] { get set }
     
     var preferredServer: Server? { get set }
-
-    var preferredPort: UInt16? { get set }
     
     func ping(forServerIdentifier serverIdentifier: String) -> Int?
     

--- a/PIALibrary/Sources/Core/VPN/VPNConfiguration.swift
+++ b/PIALibrary/Sources/Core/VPN/VPNConfiguration.swift
@@ -23,9 +23,6 @@ public struct VPNConfiguration {
     /// The `Server` to connect to.
     public let server: Server
 
-    /// A custom port to connect to.
-    public let port: UInt16?
-    
     /// When `true`, the VPN will connect on demand.
     public let isOnDemand: Bool
 
@@ -42,9 +39,6 @@ public struct VPNConfiguration {
 ///
 /// - Seealso: `VPNProfile`
 public protocol VPNCustomConfiguration {
-
-    /// Returns `true` if connects via TCP.
-    var isTCP: Bool { get }
 
     /**
      Returns a dictionary representation of this configuration.

--- a/PIALibrary/Sources/Library/Persistence/UserDefaultsStore.swift
+++ b/PIALibrary/Sources/Library/Persistence/UserDefaultsStore.swift
@@ -26,8 +26,6 @@ class UserDefaultsStore: PlainStore, ConfigurationAccess {
         
         static let preferredServer = "CurrentRegion" // legacy
 
-        static let preferredPort = "PreferredPort"
-        
         static let pingByServerIdentifier = "PingByServerIdentifier"
         
         static let vpnType = "VPNType"
@@ -145,19 +143,6 @@ class UserDefaultsStore: PlainStore, ConfigurationAccess {
         }
         set {
             backend.set(newValue?.identifier, forKey: Entries.preferredServer)
-        }
-    }
-    
-    var preferredPort: UInt16? {
-        get {
-            let port = backend.integer(forKey: Entries.preferredPort)
-            guard (port > 0) else {
-                return nil
-            }
-            return UInt16(port)
-        }
-        set {
-            backend.set(newValue, forKey: Entries.preferredPort)
         }
     }
     

--- a/PIALibrary/Sources/Library/VPN/DefaultVPNProvider.swift
+++ b/PIALibrary/Sources/Library/VPN/DefaultVPNProvider.swift
@@ -243,24 +243,11 @@ class DefaultVPNProvider: VPNProvider, ConfigurationAccess, DatabaseAccess, Pref
 
         let customConfiguration = accessedPreferences.vpnCustomConfiguration(for: profile.vpnType)
 
-        var port = accessedPreferences.preferredPort
-        if (port == nil), let cfg = customConfiguration {
-            let targetServer = accessedProviders.serverProvider.targetServer
-            if cfg.isTCP {
-                port = targetServer.bestOpenVPNAddressForTCP?.port ??
-                    accessedDatabase.transient.serversConfiguration.vpnPorts.tcp.first
-            } else {
-                port = targetServer.bestOpenVPNAddressForUDP?.port ??
-                    accessedDatabase.transient.serversConfiguration.vpnPorts.udp.first
-            }
-        }
-
         return VPNConfiguration(
             name: accessedConfiguration.vpnProfileName,
             username: currentUser.credentials.username,
             passwordReference: currentPasswordReference,
             server: accessedProviders.serverProvider.targetServer,
-            port: port,
             isOnDemand: accessedPreferences.isPersistentConnection,
             disconnectsOnSleep: accessedPreferences.vpnDisconnectsOnSleep,
             customConfiguration: customConfiguration

--- a/PIALibrary/Sources/VPN/PIATunnelProfile.swift
+++ b/PIALibrary/Sources/VPN/PIATunnelProfile.swift
@@ -12,8 +12,6 @@ import NetworkExtension
 
 /// Implementation of `VPNProfile` providing OpenVPN connectivity.
 public class PIATunnelProfile: NetworkExtensionProfile {
-    private static let defaultPort: UInt16 = 1194
-
     private let bundleIdentifier: String
 
     /**
@@ -169,8 +167,7 @@ public class PIATunnelProfile: NetworkExtensionProfile {
         
         cfg.username = configuration.username
         cfg.passwordReference = configuration.passwordReference
-        let port = configuration.port ?? PIATunnelProfile.defaultPort
-        cfg.serverAddress = "\(configuration.server.hostname):\(port)"
+        cfg.serverAddress = configuration.server.hostname
         cfg.providerBundleIdentifier = bundleIdentifier
         
         var customCfg = configuration.customConfiguration

--- a/PIALibrary/Sources/VPN/PIATunnelProvider+Profile.swift
+++ b/PIALibrary/Sources/VPN/PIATunnelProvider+Profile.swift
@@ -11,10 +11,6 @@ import PIATunnel
 
 /// :nodoc:
 extension PIATunnelProvider.Configuration: VPNCustomConfiguration {
-    public var isTCP: Bool {
-        return (socketType == .tcp)
-    }
-    
     public func serialized() -> [String: Any] {
         return generatedProviderConfiguration()
     }
@@ -26,7 +22,7 @@ extension PIATunnelProvider.Configuration: VPNCustomConfiguration {
         guard (appGroup == other.appGroup) else {
             return false
         }
-        guard (socketType == other.socketType) else {
+        guard (endpointProtocols == other.endpointProtocols) else {
             return false
         }
         guard (cipher == other.cipher) else {

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ abstract_target 'PIALibrary' do
     pod 'Alamofire', '~> 4'
     pod 'ReachabilitySwift'
     #pod 'PIATunnel', :git => 'https://github.com/pia-foss/tunnel-apple.git', :commit => 'dfe7f3c'
-    pod 'PIATunnel', '~> 1.1.2'
+    pod 'PIATunnel', '~> 1.1.3'
 
     target 'PIALibrary-iOS' do
         platform :ios, '9.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,13 +2,13 @@ PODS:
   - Alamofire (4.7.2)
   - Gloss (2.0.1)
   - OpenSSL-Apple (1.1.0h)
-  - PIATunnel (1.1.2):
-    - PIATunnel/AppExtension (= 1.1.2)
-    - PIATunnel/Core (= 1.1.2)
-  - PIATunnel/AppExtension (1.1.2):
+  - PIATunnel (1.1.3):
+    - PIATunnel/AppExtension (= 1.1.3)
+    - PIATunnel/Core (= 1.1.3)
+  - PIATunnel/AppExtension (1.1.3):
     - PIATunnel/Core
     - SwiftyBeaver
-  - PIATunnel/Core (1.1.2):
+  - PIATunnel/Core (1.1.3):
     - OpenSSL-Apple (~> 1.1.0h)
     - SwiftyBeaver
   - ReachabilitySwift (4.1.0)
@@ -17,7 +17,7 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4)
   - Gloss (~> 2)
-  - PIATunnel (~> 1.1.2)
+  - PIATunnel (~> 1.1.3)
   - ReachabilitySwift
   - SwiftyBeaver (~> 1.4)
 
@@ -34,10 +34,10 @@ SPEC CHECKSUMS:
   Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
   Gloss: 1e8743f8de1fbe14a97f220ff901cba91ae5f8f8
   OpenSSL-Apple: cd153d705ef350eb834ae7ff5f21f792b51ed208
-  PIATunnel: c86cb855e2fb5ad217e6123884ec61fae736636f
+  PIATunnel: b869c1cb9844931e969d24a585483b7e16e1a582
   ReachabilitySwift: 6849231cd4e06559f3b9ef4a97a0a0f96d41e09f
   SwiftyBeaver: 25bd76281f49ca989ec2e3cbde9af89c15bc1432
 
-PODFILE CHECKSUM: 1ab050612d892c5a6d50032b1aabac0094b289f3
+PODFILE CHECKSUM: 3e4aec82d84584c5df779a4becf3ebe2f3a6a3ee
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
PIATunnel 1.1.3 breaks with removal of socketType, deprecation was too expensive. Drop preferredPort, leave it protocol-specific.