### PR TITLE
Fall back to default VPN custom configuration

### DIFF
--- a/PIALibrary/Sources/Library/Client+Preferences.swift
+++ b/PIALibrary/Sources/Library/Client+Preferences.swift
@@ -132,7 +132,7 @@ extension Client {
                 var allConfigurations: [String: VPNCustomConfiguration] = [:]
                 for (vpnType, map) in allMaps {
                     let profile = configuration.profile(forVPNType: vpnType)
-                    guard let configuration = profile?.parsedCustomConfiguration(from: map) else {
+                    guard let configuration = profile?.parsedCustomConfiguration(from: map) ?? defaults.vpnCustomConfiguration(for: vpnType) else {
                         continue
                     }
                     allConfigurations[vpnType] = configuration


### PR DESCRIPTION
Custom configuration for `PIATunnelProfile` must fall back to defaults in case any error occurs.