### PR TITLE
Remove access qualifier from password read query

### DIFF
--- a/PIALibrary/Sources/Util/Keychain.swift
+++ b/PIALibrary/Sources/Util/Keychain.swift
@@ -92,7 +92,7 @@ public class Keychain {
         setScope(query: &query)
         query[kSecClass as String] = kSecClassGenericPassword
         query[kSecAttrAccount as String] = username
-        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        //query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         query[kSecReturnData as String] = true
         


### PR DESCRIPTION
Only meaningful in setter, restriction is unnecessary in getter.

Fixes #9