### PR TITLE
KM-13283 Fix crash around NetworkExtensionProfile

### DIFF
--- a/.github/workflows/pia_ios_client_library.yml
+++ b/.github/workflows/pia_ios_client_library.yml
@@ -14,9 +14,11 @@ jobs:
       - name: Setup Git credentials
         run: |
           git config --global url."https://${{ secrets.ORG_GITHUB_USERNAME }}:${{ secrets.ORG_GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+
       - uses: actions/checkout@v3
+
       - name: Select XCode version
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+        run: sudo xcode-select -s /Applications/Xcode_16.4.0.app
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pia_ios_client_library.yml
+++ b/.github/workflows/pia_ios_client_library.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Test
         run: |
           set -o pipefail
-          xcodebuild -scheme 'PIALibrary' -destination "platform=iOS Simulator,OS=latest,name=iPhone 15"  \
+          xcodebuild -scheme 'PIALibrary' -destination "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro"  \
             -skip-testing:PIALibraryTests/EndpointManagerTests \
             -skip-testing:PIALibraryTests/AccountTests \
             -skip-testing:PIALibraryTests/AccountInfoTests \

--- a/.github/workflows/pia_ios_client_library.yml
+++ b/.github/workflows/pia_ios_client_library.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   macos:
     name: build and test
-    runs-on: macos-13
+    runs-on: macos-26
     timeout-minutes: 30
     steps:
       - name: Setup Git credentials

--- a/.github/workflows/pia_ios_client_library.yml
+++ b/.github/workflows/pia_ios_client_library.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: | 
           set -o pipefail
-          xcodebuild -scheme 'PIALibrary' -configuration Debug -destination "platform=iOS Simulator,OS=latest,name=iPhone 15" build | xcpretty
+          xcodebuild -scheme 'PIALibrary' -configuration Debug -destination "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro" build | xcpretty
           exit ${PIPESTATUS[0]}
       
       - name: Test

--- a/Sources/PIALibrary/ClientError.swift
+++ b/Sources/PIALibrary/ClientError.swift
@@ -55,6 +55,9 @@ public enum ClientError: Error, Equatable {
     /// Error while checking the dip token renewal.
     case dipTokenRenewalError
 
+    /// The Wireguard Token is missing.
+    case missingWireguardToken
+
     #if os(iOS) || os(tvOS)
     /// No in-app history receipt is available.
     case noReceipt

--- a/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
+++ b/Sources/PIALibrary/VPN/NetworkExtensionProfile.swift
@@ -36,7 +36,7 @@ public protocol NetworkExtensionProfile: VPNProfile {
      - Parameter configuration: The `VPNConfiguration` to build the protocol upon.
      - Returns: A native `NEVPNProtocol` object for use with NetworkExtension.
      */
-    func generatedProtocol(withConfiguration configuration: VPNConfiguration) -> NEVPNProtocol
+    func generatedProtocol(withConfiguration configuration: VPNConfiguration) throws -> NEVPNProtocol
 }
 
 @available(tvOS 17.0, *)
@@ -66,7 +66,13 @@ extension NetworkExtensionProfile {
      - Seealso: `NetworkExtensionProfile.generatedProtocol(...)`
      */
     public func doSave(_ vpn: NEVPNManager, withConfiguration configuration: VPNConfiguration, force: Bool, _ callback: SuccessLibraryCallback?) {
-        vpn.protocolConfiguration = generatedProtocol(withConfiguration: configuration)
+        do {
+            vpn.protocolConfiguration = try generatedProtocol(withConfiguration: configuration)
+        } catch {
+            callback?(error)
+            return
+        }
+
         guard let protocolConfiguration = vpn.protocolConfiguration else {
             fatalError("Never provided a configuration?")
         }


### PR DESCRIPTION
**Summary**

- Fail gracefully in case of missing WireGuard token instead of crash the app.
- Remove iOS 12.0 availability check since 12 is already the minimum version.

This PR fixes/implements the following **bugs/features**

* [x] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

**Test plan (required)**

**Code formatting**

**Closing issues**